### PR TITLE
fix error caused by unknown extension

### DIFF
--- a/lib/extensions.py
+++ b/lib/extensions.py
@@ -99,6 +99,9 @@ class Extensions:
             c.execute('SELECT title,version,state FROM extensions where extensionkey=?', (extension,))
             data = c.fetchone()
             print(Style.BRIGHT + '  [+] {}'.format(Fore.GREEN  + extension + Style.RESET_ALL))
+            if data is None:
+                print('   \u251c Extension ({}) is unknown'.format(extension))
+                continue
             print('   \u251c Extension Title: '.ljust(28) + '{}'.format(data[0]))
             print('   \u251c Extension Repo: '.ljust(28) + 'https://extensions.typo3.org/extension/{}'.format(extension))
             print('   \u251c Current Version: '.ljust(28) + '{} ({})'.format(data[1], data[2]))


### PR DESCRIPTION
This fixed a problem for me, when the found extension is not in the database, which caused the script to fail.