### PR TITLE
added database variable declaration when checking extensions when using a custom user-agent

### DIFF
--- a/typo3scan.py
+++ b/typo3scan.py
@@ -83,6 +83,7 @@ class Typo3:
                     # Search extensions
                     print('\n [+] Extension Search')
                     if not self.__extensions:
+                        database = os.path.join(self.__path, 'lib', 'typo3scan.db')
                         conn = sqlite3.connect(database)
                         c = conn.cursor()
                         if args.vuln:


### PR DESCRIPTION
If a customer user-agent is defined using the command-line argument `--agent` the script fails with the following error
```
 [+] Extension Search
Traceback (most recent call last):
  File "./typo3scan.py", line 199, in <module>
    main.run()
  File "./typo3scan.py", line 86, in run
    conn = sqlite3.connect(database)
                    check_404 = check.check_404()
UnboundLocalError: local variable 'database' referenced before assignment
```

The `database` variable is only ever set on line 43.  This is part of the if/else statement that checks if the `--agent` command-line arg was present.   See below.

```
        if (args.user_agent):
            user_agent = args.user_agent
        else:
            database = os.path.join(self.__path, 'lib', 'typo3scan.db')
            conn = sqlite3.connect(database)
            c = conn.cursor()
            c.execute('SELECT * FROM UserAgents ORDER BY RANDOM() LIMIT 1;')
            user_agent = c.fetchone()[0]
            c.close()
```