### PR TITLE
add setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 colorama
 progressbar
+setuptools


### PR DESCRIPTION
fix this error

```
$ python typo3scan.py -h
Traceback (most recent call last):                                                                                                                                                                                                           
  File "/usr/share/typo3scan/typo3scan.py", line 31, in <module>                                                                                                                                                                             
    from lib.domain import Domain                                                                                                                                                                                                            
  File "/usr/share/typo3scan/lib/domain.py", line 27, in <module>                                                                                                                                                                            
    from pkg_resources import parse_version                                                                                                                                                                                                  
ModuleNotFoundError: No module named 'pkg_resources'
```

it's required at runtime https://github.com/whoot/Typo3Scan/blob/669435a15f5c47b2b4357c6b7da41bee716327c5/lib/domain.py#L27