### PR TITLE
Split basic auth parameter on the first colon only

### DIFF
--- a/typo3scan.py
+++ b/typo3scan.py
@@ -62,7 +62,7 @@ class Typo3:
             self.__cookies = {name: value}
         self.__basic_auth = False
         if basic_auth:
-            self.__basic_auth = (basic_auth.split(':')[0], basic_auth.split(':')[1])
+            self.__basic_auth = basic_auth.split(':', 1)
         self.__config = {'threads': threads, 'timeout': timeout, 'auth': self.__basic_auth, 'cookies': self.__cookies, 'headers': self.__custom_headers, 'no_interaction': no_interaction}
 
     def run(self):


### PR DESCRIPTION
Currently, basic authentication fails when the provided password contains a colon (:). The reason is that the auth parameter gets split on any colon, so only the substring before the second colon gets used. Fix this by only splitting on the first occurence.