### PR TITLE
Use rawstrings to avoid warnings in Python 3.12

### DIFF
--- a/lib/domain.py
+++ b/lib/domain.py
@@ -51,7 +51,7 @@ class Domain:
         self.__typo3_vulnerabilities = []
         self.__installed_extensions = {'installed': 0}
         self.__config = config
-        
+
     def get_name(self):
         return self.__name
 
@@ -97,11 +97,11 @@ class Domain:
         """
         full_path = self.get_name()
         response = request.get_request('{}'.format(self.get_name()), self.__config)
-        if re.search('powered by TYPO3', response['html']):
+        if re.search(r'powered by TYPO3', response['html']):
             self.set_typo3()
-            path = re.search('="(?:{})/?(\S*?)/?(?:typo3temp|typo3conf)/'.format(self.get_name()), response['html'])
+            path = re.search(r'="(?:{})/?(\S*?)/?(?:typo3temp|typo3conf)/'.format(self.get_name()), response['html'])
             if path and path.group(1) != '':
-                full_path = '{}/{}'.format(self.get_name(), path)            
+                full_path = '{}/{}'.format(self.get_name(), path)
         self.set_path(full_path)
 
     def check_404(self):
@@ -112,7 +112,7 @@ class Domain:
         """
         random_string = ''.join(random.choice(string.ascii_lowercase) for i in range(10))
         response = request.get_request('{}/{}'.format(self.get_path(), random_string), self.__config)
-        search404 = re.search('[Tt][Yy][Pp][Oo]3 CMS', response['html'])
+        search404 = re.search(r'[Tt][Yy][Pp][Oo]3 CMS', response['html'])
         if search404:
             self.set_typo3()
 
@@ -124,7 +124,7 @@ class Domain:
         """
         print(' [+] Backend Login')
         response = request.get_request('{}/typo3/index.php'.format(self.get_path()), self.__config)
-        searchTitle = re.search('<title>(.*)</title>', response['html'])
+        searchTitle = re.search(r'<title>(.*)</title>', response['html'])
         if searchTitle and 'Login' in searchTitle.group(0):
             print('  \u251c {}'.format(Fore.GREEN + '{}/typo3/index.php'.format(self.get_path()) + Fore.RESET))
             self.set_backend('{}/typo3/index.php'.format(self.get_path()))

--- a/lib/extensions.py
+++ b/lib/extensions.py
@@ -61,10 +61,10 @@ class Extensions:
         """
         thread_pool = ThreadPool()
         for extension,values in found_extensions.items():
-            thread_pool.add_job((request.version_information, (values['url'] + '/composer.json', '(?:"dev-master"|"version")\s?[:=]\s?"?([0-9]+\.[0-9]+\.?[0-9x]?[0-9x]?)', self.__config)))
-            thread_pool.add_job((request.version_information, (values['url'] + '/Documentation/Settings.yml', '(?:release\s?[=:])\s?"?([0-9]+\.[0-9]+\.?[0-9]?[0-9]?)', self.__config)))
-            thread_pool.add_job((request.version_information, (values['url'] + '/Documentation/Settings.yaml', '(?:release\s?[=:])\s?"?([0-9]+\.[0-9]+\.?[0-9]?[0-9]?)', self.__config)))
-            thread_pool.add_job((request.version_information, (values['url'] + '/Documentation/Settings.cfg', '(?:release\s?[=:])\s?"?([0-9]+\.[0-9]+\.?[0-9]?[0-9]?)', self.__config)))
+            thread_pool.add_job((request.version_information, (values['url'] + '/composer.json', r'(?:"dev-master"|"version")\s?[:=]\s?"?([0-9]+\.[0-9]+\.?[0-9x]?[0-9x]?)', self.__config)))
+            thread_pool.add_job((request.version_information, (values['url'] + '/Documentation/Settings.yml', r'(?:release\s?[=:])\s?"?([0-9]+\.[0-9]+\.?[0-9]?[0-9]?)', self.__config)))
+            thread_pool.add_job((request.version_information, (values['url'] + '/Documentation/Settings.yaml', r'(?:release\s?[=:])\s?"?([0-9]+\.[0-9]+\.?[0-9]?[0-9]?)', self.__config)))
+            thread_pool.add_job((request.version_information, (values['url'] + '/Documentation/Settings.cfg', r'(?:release\s?[=:])\s?"?([0-9]+\.[0-9]+\.?[0-9]?[0-9]?)', self.__config)))
             thread_pool.add_job((request.version_information, (values['url'] + '/ChangeLog.txt', None, self.__config)))
             thread_pool.add_job((request.version_information, (values['url'] + '/Documentation/ChangeLog', None, self.__config)))
             thread_pool.add_job((request.version_information, (values['url'] + '/CHANGELOG.md', None, self.__config)))

--- a/lib/initdb.py
+++ b/lib/initdb.py
@@ -17,7 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see [http://www.gnu.org/licenses/](http://www.gnu.org/licenses/)
 #-------------------------------------------------------------------------------
-import sqlite3, os.path
+import os.path
+import sqlite3
+import sys
 
 class DB_Init:
     """
@@ -28,7 +30,7 @@ class DB_Init:
         try:
             conn = sqlite3.connect(database)
             c = conn.cursor()
-            
+
             # Delete all tables
             c.execute('''DROP TABLE IF EXISTS extensions''')
             c.execute('''DROP TABLE IF EXISTS extension_vulns''')
@@ -56,14 +58,14 @@ class DB_Init:
             # Create table UserAgents
             #c.execute('''CREATE TABLE IF NOT EXISTS UserAgents
             #             (userAgent text)''')
-            
+
             conn.commit()
 
         except sqlite3.Error as e:
             if conn:
                 conn.rollback()
             print(e)
-            exit(-1)
+            sys.exit(1)
 
         finally:
             if conn:

--- a/lib/request.py
+++ b/lib/request.py
@@ -19,7 +19,7 @@
 #-------------------------------------------------------------------------------
 
 import re
-import os.path
+import sys
 import requests
 from colorama import Fore
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -50,7 +50,7 @@ def get_request(url, config):
     except requests.exceptions.Timeout as e:
         print(e)
         print(Fore.RED + '[x] Connection error\n    Please make sure you provided the right URL\n' + Fore.RESET)
-        exit(-1)
+        sys.exit(1)
     except requests.exceptions.RequestException as e:
         print(Fore.RED + str(e) + Fore.RESET)
         # Return an empty response['html'] element.

--- a/lib/request.py
+++ b/lib/request.py
@@ -53,7 +53,7 @@ def get_request(url, config):
         exit(-1)
     except requests.exceptions.RequestException as e:
         print(Fore.RED + str(e) + Fore.RESET)
-        # Return an empty response['html'] element. 
+        # Return an empty response['html'] element.
         # If this error occurs within the first request made (TYPO3 detection), then all following scans will be canceled
         response['html'] = ''
         return response
@@ -89,7 +89,7 @@ def version_information(url, regex, config):
         because usually the TYPO3 version is in the first few lines of the response.
     """
     if regex is None:
-        regex = '([0-9]+\.[0-9]+\.[0-9x][0-9x]?)'
+        regex = r'([0-9]+\.[0-9]+\.[0-9x][0-9x]?)'
     try:
         if config['auth']:
             r = requests.get(url, stream=True, timeout=config['timeout'], headers=config['headers'], auth=(config['auth'][0], config['auth'][1]), verify=False)
@@ -103,7 +103,7 @@ def version_information(url, regex, config):
                     version = search.group(1)
                 except:
                     try:
-                        search = re.search('([0-9]+-[0-9]+-[0-9]+)', str(content))
+                        search = re.search(r'([0-9]+-[0-9]+-[0-9]+)', str(content))
                         version = search.group(1)
                     except:
                         continue

--- a/lib/thread_pool.py
+++ b/lib/thread_pool.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see [http://www.gnu.org/licenses/](http://www.gnu.org/licenses/)
 #-------------------------------------------------------------------------------
 
+import sys
 import threading
 from queue import Queue
 from progressbar import Bar, AdaptiveETA, Percentage, ProgressBar
@@ -82,7 +83,7 @@ class ThreadPool:
 			[self.__work_queue.put(ThreadPoolSentinel()) for worker in self.__thread_list]
 		except KeyboardInterrupt:
 			print('\nReceived keyboard interrupt.\nQuitting...')
-			exit(-1)
+			sys.exit(1)
 
 	def join(self): # Clean exit
 		self.__work_queue.join()

--- a/lib/update.py
+++ b/lib/update.py
@@ -34,7 +34,7 @@ class Update:
     """
     This class updates the extension and vulnerability database
 
-    It will download the extension file from the official repository, 
+    It will download the extension file from the official repository,
     unpack it and insert the extensions in the database.
     Vulnerabilities will be parsed from the official homepage.
     """
@@ -61,7 +61,7 @@ class Update:
     def load_core_vulns(self):
         """
             Grep the CORE vulnerabilities from the security advisory website
-            
+
             Search for advisories and maximum pages
             Request every advisory and get:
                 Advisory Title
@@ -97,10 +97,10 @@ class Update:
 
                 # set as global versions
                 advisory_items = {}
-                subcomponents = re.findall('([sS]ubcomponent\s?#?[0-9]?:\s?(.*?))<', beauty_html)
+                subcomponents = re.findall(r'([sS]ubcomponent\s?#?[0-9]?:\s?(.*?))<', beauty_html)
                 # if no subcomponent / CORE vuln
                 if len(subcomponents) == 0:
-                    missed = re.search('Component Type:\s?(.*?)<', beauty_html).group(1)
+                    missed = re.search(r'Component Type:\s?(.*?)<', beauty_html).group(1)
                     advisory_items[missed] = []
                     advisory_items[missed].append(beauty_html)
                 subcomponents.reverse()
@@ -116,7 +116,7 @@ class Update:
 
                     for subcomponent, entry in advisory_items.items():
                         vulnerability_items = {}
-                        vulnerability_type = re.findall('(Vulnerability Type:\s?(.*?)<)', entry[0])
+                        vulnerability_type = re.findall(r'(Vulnerability Type:\s?(.*?)<)', entry[0])
                         vulnerability_type.reverse()
                         for type_entry in vulnerability_type:
                             index = entry[0].rfind(type_entry[0])
@@ -125,24 +125,24 @@ class Update:
                             entry[0] = entry[0][:index]
 
                         for vuln_type, vuln_description in vulnerability_items.items():
-                            severity = re.search('Severity:\s?(.+?)<', vuln_description[0])
+                            severity = re.search(r'Severity:\s?(.+?)<', vuln_description[0])
                             if severity:
                                 severity = severity.group(1)
                             else:
                                 print("ERROR! GOT SEVERITY:", severity)
                                 severity = 'None assigned'
-                            search_affected = re.search('Affected Version[s]?:\s?(.+?)<', vuln_description[0])
+                            search_affected = re.search(r'Affected Version[s]?:\s?(.+?)<', vuln_description[0])
                             if search_affected:
                                 affected_versions = search_affected.group(1)
                             else:
-                                affected_versions = re.search('Affected Version[s]?:\s?(.+?)<', beauty_html).group(1)
+                                affected_versions = re.search(r'Affected Version[s]?:\s?(.+?)<', beauty_html).group(1)
                             # separate versions
                             affected_versions = affected_versions.replace("and below", " - 0.0.0")
                             affected_versions = affected_versions.replace(";", ",")
                             affected_versions = affected_versions.replace(' and', ',')
                             versions = affected_versions.split(', ')
                             for version in versions:
-                                version = re.findall('([0-9]+\.[0-9x]+\.?[0-9x]?[0-9x]?)', version)
+                                version = re.findall(r'([0-9]+\.[0-9x]+\.?[0-9x]?[0-9x]?)', version)
                                 if len(version) == 0:
                                     print("[!] Unknown version info! Skipping...")
                                     print(" \u251c Advisory:", advisory)
@@ -191,7 +191,7 @@ class Update:
             next_page = self.get_next_page_from_advisory(response)
             if next_page:
                 url = 'https://typo3.org' + next_page
-                current_page += 1  
+                current_page += 1
             else:
                 url = None
 
@@ -225,7 +225,7 @@ class Update:
             Parse the extension file and add extensions in database
         """
         print('\n \u251c Parsing extension file...')
-        tree = ElementTree.parse('extensions.xml') 
+        tree = ElementTree.parse('extensions.xml')
         root = tree.getroot()
 
         c.execute('''DROP TABLE IF EXISTS extensions''')
@@ -268,7 +268,7 @@ class Update:
     def load_extension_vulns(self):
         """
             Grep the EXTENSION vulnerabilities from the security advisory website
-            
+
             Search for advisories and maximum pages
             Request every advisory and get:
                 Advisory Title
@@ -310,11 +310,11 @@ class Update:
                         beauty_html = beauty_html.replace('</strong>', '')
                         beauty_html = beauty_html.replace('&nbsp;', ' ')
                         beauty_html = beauty_html.replace('&amp;', '&')
-                        advisory_info = re.search('<title>(.*)</title>', beauty_html).group(1)
-                        vulnerability = re.findall('Vulnerability Type[s]?:\s?(.*?)<', beauty_html)
-                        affected_versions = re.findall('Affected Version[s]?:\s?(.+?)<', beauty_html)
-                        extensionkey = re.findall('Extension[s]?:\s?(.*?)<', beauty_html)
-                        severity = re.search('Severity:\s?(.+?)<', beauty_html)
+                        advisory_info = re.search(r'<title>(.*)</title>', beauty_html).group(1)
+                        vulnerability = re.findall(r'Vulnerability Type[s]?:\s?(.*?)<', beauty_html)
+                        affected_versions = re.findall(r'Affected Version[s]?:\s?(.+?)<', beauty_html)
+                        extensionkey = re.findall(r'Extension[s]?:\s?(.*?)<', beauty_html)
+                        severity = re.search(r'Severity:\s?(.+?)<', beauty_html)
                         if severity:
                             severity = severity.group(1)
                         else:
@@ -342,7 +342,7 @@ class Update:
                             version_item = version_item.replace(' and', ',')
                             versions = version_item.split(', ')
                             for version in versions:
-                                version = re.findall('([0-9]+\.[0-9x]+\.[0-9x]+)', version)
+                                version = re.findall(r'([0-9]+\.[0-9x]+\.[0-9x]+)', version)
                                 if len(version) == 1:
                                     affected_version_max = version[0]
                                     affected_version_min = version[0]
@@ -382,6 +382,6 @@ class Update:
             next_page = self.get_next_page_from_advisory(response)
             if next_page:
                 url = 'https://typo3.org' + next_page
-                current_page += 1  
+                current_page += 1
             else:
                 url = None

--- a/lib/update.py
+++ b/lib/update.py
@@ -171,7 +171,7 @@ class Update:
                 except Exception as e:
                     print("Error on receiving data for https://typo3.org/security/advisory/{}".format(advisory))
                     print(e)
-                    exit(-1)
+                    sys.exit(1)
 
                 # Add vulnerability details to database
                 for core_vuln in vulnerabilities:
@@ -357,7 +357,7 @@ class Update:
                     except Exception as e:
                         print("Error on receiving data for https://typo3.org/security/advisory/{}".format(advisory))
                         print(e)
-                        exit(-1)
+                        sys.exit(1)
 
                 # Add vulnerability details to database
                 for ext_vuln in vulnerabilities:

--- a/typo3scan.py
+++ b/typo3scan.py
@@ -112,7 +112,7 @@ class Typo3:
                 json.dump(self.__json_log, open(self.__json, 'w'))
         except KeyboardInterrupt:
             print('\nReceived keyboard interrupt.\nQuitting...')
-            exit(-1)
+            sys.exit(1)
         finally:
             deinit()
 
@@ -243,7 +243,7 @@ Options:
         data = c.fetchall()
         if (len(data) == 0):
             print('\n' + Fore.RED + Style.BRIGHT + '[!] Extension \'{}\' does not exist\n'.format(name) + Style.RESET_ALL)
-            sys.exit(-1)
+            sys.exit(1)
         else:
             c.execute('SELECT advisory, vulnerability, affected_version_max, affected_version_min, severity FROM extension_vulns WHERE (extensionkey=? AND ?<=affected_version_max AND ?>=affected_version_min)', (name, version, version,))
             data = c.fetchall()
@@ -278,7 +278,7 @@ Options:
         elif args.file:
             if not os.path.isfile(args.file):
                 print(Fore.RED + '\n[x] File not found: {}\n |  Aborting...'.format(args.file) + Fore.RESET)
-                sys.exit(-1)
+                sys.exit(1)
             else:
                 with open(args.file, 'r') as f:
                     for line in f:

--- a/typo3scan.py
+++ b/typo3scan.py
@@ -50,7 +50,7 @@ class Typo3:
         self.__vuln = vuln
         if not user_agent:
             conn = sqlite3.connect(self.__database)
-            c = conn.cursor()       
+            c = conn.cursor()
             c.execute('SELECT * FROM UserAgents ORDER BY RANDOM() LIMIT 1;')
             user_agent = c.fetchone()[0]
             c.close()
@@ -115,21 +115,21 @@ class Typo3:
             exit(-1)
         finally:
             deinit()
-        
+
 if __name__ == '__main__':
     print('\n' + 73*'=' + Style.BRIGHT)
     print(Fore.CYAN)
-    print('________                   ________   _________                     '.center(73))
-    print('\_    _/__ __ ______  _____\_____  \ /   _____/ ____ _____    ___  '.center(73))
-    print('  |  | |  |  |\____ \|  _  | _(__  < \_____  \_/ ___\\\\__  \  /   \ '.center(73))
-    print('  |  | |___  ||  |_) | (_) |/       \/        \  \___ / __ \|  |  \ '.center(73))
-    print('  |__| / ____||   __/|_____|________/_________/\_____|_____/|__|__/ '.center(73))
-    print('       \/     |__|                                                  '.center(73))
+    print(r'________                   ________   _________                     '.center(73))
+    print(r'\_    _/__ __ ______  _____\_____  \ /   _____/ ____ _____    ___  '.center(73))
+    print(r'  |  | |  |  |\____ \|  _  | _(__  < \_____  \_/ ___\\\\__  \  /   \ '.center(73))
+    print(r'  |  | |___  ||  |_) | (_) |/       \/        \  \___ / __ \|  |  \ '.center(73))
+    print(r'  |__| / ____||   __/|_____|________/_________/\_____|_____/|__|__/ '.center(73))
+    print(r'       \/     |__|                                                  '.center(73))
     print(Fore.RESET + Style.RESET_ALL)
     print(__description__.center(73))
     print(('Version ' + __version__).center(73))
     print((__author__).center(73))
-    print(73*'=')    
+    print(73*'=')
 
     def print_help():
         print(
@@ -149,16 +149,16 @@ Options:
    You dont need to specify this arguments, but you may want to
 
     --vuln              Check for extensions with known vulnerabilities only.
-              
+
     --timeout TIMEOUT   Request Timeout.
                         Default: 10 seconds
-              
+
     --auth USER:PASS    Username and Password for HTTP Basic Authorization.
-    
+
     --cookie NAME=VALUE Can be used for authenticiation based on cookies.
 
     --agent USER-AGENT  Set custom User-Agent for requests.
-         
+
     --threads THREADS   The number of threads to use for enumerating extensions.
                         Default: 5
 
@@ -192,7 +192,7 @@ Options:
     parser.add_argument('--timeout', dest='timeout', type=int, default=10)
     parser.add_argument('--json', dest='json', type=str, default=os.path.join(os.getcwd(), 'typo3scan.json'))
     parser.add_argument('--no-interaction', dest='no_interaction', action='store_true')
-    
+
     help.add_argument( '-h', '--help', action='store_true')
     args = parser.parse_args()
 
@@ -207,7 +207,7 @@ Options:
         database = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'lib', 'typo3scan.db')
         conn = sqlite3.connect('lib/typo3scan.db')
         c = conn.cursor()
-        c.execute('SELECT advisory, vulnerability, subcomponent, affected_version_max, affected_version_min, severity FROM core_vulns WHERE (?<=affected_version_max AND ?>=affected_version_min)', (args.core, args.core,)) 
+        c.execute('SELECT advisory, vulnerability, subcomponent, affected_version_max, affected_version_min, severity FROM core_vulns WHERE (?<=affected_version_max AND ?>=affected_version_min)', (args.core, args.core,))
         data = c.fetchall()
         json_list = {}
         if data:
@@ -238,7 +238,7 @@ Options:
         else:
             name = (args.extension).split(':')[0]
             version = (args.extension).split(':')[1]
-        
+
         c.execute('SELECT ROWID FROM extensions WHERE extensionkey=?', (name,))
         data = c.fetchall()
         if (len(data) == 0):
@@ -270,7 +270,7 @@ Options:
         if args.force:
            print('\n' + Fore.RED + Style.BRIGHT + '!! FORCE MODE ENABLED !!'.center(73))
            print('!! Expect False Positives !!'.center(73) + Style.RESET_ALL)
-        
+
         domain_list = list()
         if args.domain:
             for dom in args.domain:


### PR DESCRIPTION
When running Typo3Scan with Python 3.12, it emits several warnings like

> SyntaxWarning: invalid escape sequence '\S'

The first commit fixes this by using rawstrings, which are escpecially recommended for regular expressions.

The second commit is another cleanup commit that concerns uses of `exit(-1)`. Exit codes cannot be negative since they are unsigned 8-bit integers, hence must be between 0 and 255. Besides, `sys.exit()` is recommended over `exit()`.